### PR TITLE
Refresh profile README with current skills and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,159 @@
-### Hi there 👋
+<div align="center">
 
+<img width="100%" src="https://capsule-render.vercel.app/api?type=waving&color=0:00C2FF,50:7F5AF0,100:FF4D9D&height=230&section=header&text=Ritchie%20Kumar&fontSize=52&fontColor=ffffff&animation=fadeIn&fontAlignY=36&desc=Software%20Engineer%20%C3%97%20Computer%20Engineer&descAlignY=57&descSize=20" alt="Ritchie Kumar — Software Engineer and Computer Engineer" />
 
-<!--
-**SuperRitchie/SuperRitchie** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+<sub>Note: This document was made with AI assistance (ChatGPT)</sub>
 
-Here are some ideas to get you started:
+<br><br>
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
-![](https://komarev.com/ghpvc/?username=SuperRitchie)
+<a href="https://ritchiek.tech">
+  <img src="https://img.shields.io/badge/Portfolio-ritchiek.tech-00C2FF?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Portfolio" />
+</a>
+<a href="https://github.com/SuperRitchie?tab=repositories">
+  <img src="https://img.shields.io/badge/Explore-My_Projects-7F5AF0?style=for-the-badge&logo=github&logoColor=white" alt="Explore my projects" />
+</a>
+<img src="https://img.shields.io/badge/Open_to_Work-Software_Engineering-FF4D9D?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Open to software engineering opportunities" />
+
+<br><br>
+
+<img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=20&duration=2800&pause=850&color=58A6FF&center=true&vCenter=true&width=820&lines=Building+automation+that+survives+the+real+world;Training+chess+AI+with+continuous+self-play;Connecting+web%2C+cloud%2C+data%2C+and+embedded+systems" alt="Animated introduction" />
+
+</div>
+
+## `> whoami`
+
+I'm a Vancouver-based software engineer and **Engineer in Training (EIT)** with a **B.A.Sc. in Computer Engineering from Simon Fraser University**. I enjoy building systems that cross boundaries: browser automation backed by cloud workflows, intelligent applications trained from real data, and embedded software connected to physical hardware.
+
+My sweet spot is turning a messy real-world process into something reliable, testable, and useful.
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### ⚡ What I build
+
+- Full-stack applications and REST APIs
+- Resilient browser and workflow automation
+- CI/CD pipelines and automated test systems
+- Data-driven AI and computer vision tools
+- Linux and Raspberry Pi embedded systems
+
+</td>
+<td width="50%" valign="top">
+
+### 🎯 What I bring
+
+- Production QA and software development experience
+- TypeScript, Python, Java, C++, Go, and SQL
+- React, Node.js, Playwright, Docker, and GitHub Actions
+- Databases, cloud services, networking, and hardware integration
+- An engineering mindset focused on measurable improvement
+
+</td>
+</tr>
+</table>
+
+## `> tech --stack`
+
+<div align="center">
+
+### Languages and application development
+
+<img src="https://skillicons.dev/icons?i=ts,js,python,java,cpp,go,react,nodejs,html,css&theme=dark" alt="TypeScript, JavaScript, Python, Java, C++, Go, React, Node.js, HTML, and CSS" />
+
+### Data, infrastructure, AI, and embedded
+
+<img src="https://skillicons.dev/icons?i=docker,githubactions,git,linux,azure,postgres,mysql,tensorflow,opencv,raspberrypi&theme=dark" alt="Docker, GitHub Actions, Git, Linux, Azure, PostgreSQL, MySQL, TensorFlow, OpenCV, and Raspberry Pi" />
+
+<br><br>
+
+<img src="https://img.shields.io/badge/Playwright-2EAD33?style=flat-square&logo=playwright&logoColor=white" alt="Playwright" />
+<img src="https://img.shields.io/badge/REST_APIs-005571?style=flat-square&logo=fastapi&logoColor=white" alt="REST APIs" />
+<img src="https://img.shields.io/badge/SQL_Server-CC2927?style=flat-square&logo=microsoftsqlserver&logoColor=white" alt="SQL Server" />
+<img src="https://img.shields.io/badge/Elasticsearch-005571?style=flat-square&logo=elasticsearch&logoColor=white" alt="Elasticsearch" />
+<img src="https://img.shields.io/badge/Test_Automation-25A162?style=flat-square&logo=checkmarx&logoColor=white" alt="Test automation" />
+<img src="https://img.shields.io/badge/Embedded_Systems-8A2BE2?style=flat-square&logo=espressif&logoColor=white" alt="Embedded systems" />
+
+</div>
+
+## `> projects --featured`
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### ♟️ [Self-improving Chess AI](https://github.com/SuperRitchie/chess)
+
+A playable React chess app with random, negamax, and neural MCTS opponents. Nightly workflows combine self-play, Stockfish-labelled positions, holdout validation, and candidate-versus-baseline arenas so stronger checkpoints can promote themselves.
+
+`React` `TensorFlow.js` `Python` `MCTS` `GitHub Actions`
+
+[Play it live →](https://superritchie.github.io/chess/)
+
+</td>
+<td width="50%" valign="top">
+
+### 📅 [Schedule Automation Platform](https://github.com/SuperRitchie/adp_schedule_auto)
+
+A resilient Playwright pipeline that captures multi-week schedules, parses virtualized UI data, produces CSV, JSON, and per-person ICS calendars, then delivers outputs through GitHub Actions and Google Drive.
+
+`Node.js` `Python` `Playwright` `OAuth` `ICS`
+
+[View the project →](https://github.com/SuperRitchie/adp_schedule_auto)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+### 🚗 [NPITS Embedded Safety System](https://github.com/SuperRitchie/npits-firmware)
+
+A capstone platform joining Raspberry Pi 5 firmware, GoPro video, radar and LiDAR sensing, computer vision, SQLite, and an Android map interface for smarter road-safety data collection.
+
+`C++` `Raspberry Pi` `OpenCV` `SQLite` `Android`
+
+[Explore firmware →](https://github.com/SuperRitchie/npits-firmware) · [Explore the app →](https://github.com/SuperRitchie/npits-app)
+
+</td>
+<td width="50%" valign="top">
+
+### 🎥 [Self-updating YouTube Video](https://github.com/SuperRitchie/this-video-has-x-views)
+
+A Python automation inspired by Tom Scott that uses the YouTube Data API and a scheduled GitHub Actions workflow to keep a video's title and description synchronized with its live analytics.
+
+`Python` `YouTube API` `OAuth 2.0` `GitHub Actions`
+
+[View the automation →](https://github.com/SuperRitchie/this-video-has-x-views)
+
+</td>
+</tr>
+</table>
+
+<div align="center">
+
+**Also building:** [live transit visualizations](https://github.com/SuperRitchie/TransLink-API) · [browser-based U-Pass automation](https://github.com/SuperRitchie/Automatic-U-Pass-BC-Renewer) · [Azure ML systems](https://github.com/SuperRitchie/azureml-example)
+
+</div>
+
+## `> github --analytics`
+
+<div align="center">
+
+<img height="175" src="https://github-readme-stats.vercel.app/api?username=SuperRitchie&show_icons=true&theme=tokyonight&hide_border=true&border_radius=14&rank_icon=github" alt="Ritchie's GitHub stats" />
+<img height="175" src="https://github-readme-stats.vercel.app/api/top-langs/?username=SuperRitchie&layout=compact&langs_count=8&theme=tokyonight&hide_border=true&border_radius=14" alt="Ritchie's most used languages" />
+
+<br>
+
+<img width="96%" src="https://github-readme-activity-graph.vercel.app/graph?username=SuperRitchie&bg_color=0D1117&color=58A6FF&line=7F5AF0&point=FF4D9D&area=true&hide_border=true&radius=14" alt="Ritchie's contribution activity graph" />
+
+<br>
+
+<img src="https://komarev.com/ghpvc/?username=SuperRitchie&style=for-the-badge&color=7F5AF0&label=PROFILE+VIEWS" alt="Profile views" />
+
+### Let's build something useful
+
+I'm open to software engineering opportunities where I can work across application development, automation, data, AI, and systems engineering.
+
+<img width="100%" src="https://capsule-render.vercel.app/api?type=waving&color=0:FF4D9D,50:7F5AF0,100:00C2FF&height=120&section=footer" alt="" />
+
+</div>


### PR DESCRIPTION
## What changed

- Rebuilt the profile README with an animated gradient header, typing banner, skill visuals, project cards, GitHub analytics, and a matching footer
- Updated the introduction around Ritchie's current software engineering, QA automation, AI/ML, and embedded-systems experience
- Featured the chess AI, schedule automation platform, NPITS capstone, and YouTube automation projects
- Added links to the live portfolio, playable chess app, repositories, and related builds
- Added current education, EIT, language, framework, infrastructure, database, and hardware skills

## Why

The previous README was still the default GitHub starter and did not represent Ritchie's current degree, experience, technical range, or strongest recent work

## Impact

Visitors now get a polished, visually distinctive snapshot of Ritchie's engineering profile and can reach the most relevant projects quickly

## Validation

- Confirmed the branch is one commit ahead of `main` and zero commits behind
- Confirmed only `README.md` changed
- Re-fetched the committed README from the branch
- Verified the header, AI-assistance note, and all four featured project links are present